### PR TITLE
Improve dev/prod pages & term output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,17 @@ If you always want to show the stack traces, just use `wrap-exceptions`.
 
 The `wrap-internal-error` function allows catching errors and producing a standard error page.
 This function should be used for handling errors in production, where you do not wish to expose
-the internals of the application to the user. The function will print the stack trace to standard
-out by default.
+the internals of the application to the user. The function will print the stack trace 
+and request to standard out by default.
 
 The function accepts two keyword arguments, named `:log`  and `:error-response`. The first
 allows providing a custom log function for the exceptions and the second can be used to supply
 a custom error response.
 
 Alternatively to `:error-response`, it's possible to supply the `:error-response-handler` key that
-points to a function which can accept a map of `:request` and `:error` as a parameter and return
+points to a function which can accept `:request` and `:error` as parameters and return
 a string response that will be returned to the client. This can be useful for generating
 contextual errors based on the contents of the request.
-
-It's possible to reuse the error page in your handler like this:
-```clj
-(noir-exception.core/page :error error :request request)
-```
-e.g., to send the error page by email.
 
 ```clj
 (ns my.ns
@@ -76,4 +70,16 @@ e.g., to send the error page by email.
                                      :body "something bad happened!"})]))
 ```
 
+It's possible to reuse the error page in your handler like this:
+```clj
+(noir-exception.core/dev-page :error error :request request)
+```
+e.g., to send the error page to the developer by email.
 
+It's also possible to reuse the production page:
+```clj
+(noir-exception.core/prod-page :h "We did something dumb"
+                               :msg "Trained monkeys are fixing this mess")
+(noir-exception.core/prod-page) ; uses library default messages
+```
+e.g., to present a custom message to your users.


### PR DESCRIPTION
Calling `page` with `:error`, `:request`, or both is only useful for developers, so `page` was renamed to `dev-page`. `internal-error` is also a page, and is only useful for users, so it was renamed to `prod-page`.

When parsing `error` or `request` yields an exception, `internal-error` is not useful, and a precise message about which information failed to be presented, should be shown to the developer instead.

Not sure yet if converting request to html can fail tough.

`prod-page`’s heading and action messages should also be customizable.

Exceptions when parsing `error` or `request` should be printed along a contextual message.

All combinations for the modifications were tested in the browser and at the repl.

If something is not clear I can elaborate further.
